### PR TITLE
Sample works even faster

### DIFF
--- a/dpipe/batch_iter/sources.py
+++ b/dpipe/batch_iter/sources.py
@@ -6,9 +6,7 @@ from bisect import bisect
 
 from dpipe.itertools import pam, squeeze_first
 
-
 __all__ = 'sample', 'load_by_random_id'
-
 
 def sample(sequence: Sequence, weights: Sequence[float] = None, random_state: Union[np.random.RandomState, int] = None):
     """
@@ -29,19 +27,17 @@ def sample(sequence: Sequence, weights: Sequence[float] = None, random_state: Un
         
     if weights is None:
         # works faster than random_state.randint(0, len(sequence))
-        get_index = lambda: int(random_state.rand()*(len(sequence)))
+        L = len(sequence)
+        while True:
+            yield sequence[int(random_state.rand() * L)]
     else:
         assert(len(sequence) == len(weights)), 'len(sequence) is not equal to len(weights)'
         weights = np.asarray(weights)
         assert (weights >= 0).all() and (weights > 0).any(), weights
         weights = weights / weights.sum()
-        weights_sort_args  = np.argsort(weights)
-        weights_accum_sort = np.add.accumulate(weights[weights_sort_args])
-        get_index = lambda: weights_sort_args[bisect(weights_accum_sort,random_state.rand())]        
-        
-    while True:
-        yield sequence[get_index()]
-
+        weights_accum = np.add.accumulate(weights)
+        while True:
+            yield sequence[bisect(weights_accum, random_state.rand())]
 
 def load_by_random_id(*loaders: Callable, ids: Sequence, weights: Sequence[float] = None,
                       random_state: Union[np.random.RandomState, int] = None):

--- a/dpipe/batch_iter/sources.py
+++ b/dpipe/batch_iter/sources.py
@@ -29,7 +29,7 @@ def sample(sequence: Sequence, weights: Sequence[float] = None, random_state: Un
         # works faster than random_state.randint(0, len(sequence))
         L = len(sequence)
         while True:
-            yield sequence[int(random_state.rand() * L)]
+            yield sequence[int(random_state.random_sample() * L)]
     else:
         assert(len(sequence) == len(weights)), 'len(sequence) is not equal to len(weights)'
         weights = np.asarray(weights)
@@ -37,7 +37,7 @@ def sample(sequence: Sequence, weights: Sequence[float] = None, random_state: Un
         weights = weights / weights.sum()
         weights_accum = np.add.accumulate(weights)
         while True:
-            yield sequence[bisect(weights_accum, random_state.rand())]
+            yield sequence[bisect(weights_accum, random_state.random_sample())]
 
 def load_by_random_id(*loaders: Callable, ids: Sequence, weights: Sequence[float] = None,
                       random_state: Union[np.random.RandomState, int] = None):

--- a/dpipe/batch_iter/tests/test_sources.py
+++ b/dpipe/batch_iter/tests/test_sources.py
@@ -11,7 +11,7 @@ import time
 def test_sample():
     # multidimensional arrays support
     sequence = [[0], [1]]
-    n = 10000
+    n = 100_000
 
     def get_sum(weights=None):
         return sum(x[0] for x in islice(sample(sequence, weights), n)) / n
@@ -27,7 +27,7 @@ def test_sample_n_numpy():
     
     ids  = ['0', '1', '2', '3']
     prob = [0.15, 0.35, 0.15, 0.35]
-    N    = 10000
+    N    = 100_000
     
     def sample_bynumpy(sequence, weights):
         while True:


### PR DESCRIPTION
Сортировать массив вероятностей было не к чему.
Оказывается, что len(array) работает медленнее чем его запомнить и после обращаться к переменной.
Тесты сопоставления распределений с точностью до 2 знаков при N=10.000, очень редко, но все же проваливаются. Увеличил N на порядок.